### PR TITLE
Fix typo

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -135,7 +135,7 @@ function Set-ZLocation()
             $pushDone = $true
             break
         } else {
-            Write-Warning "There is no path $match on the file system. Removing obsolete date from datebase."
+            Write-Warning "There is no path $match on the file system. Removing obsolete data from database."
             Remove-ZLocation $match
         }
     } 


### PR DESCRIPTION
'Date' was used instead of 'data' in one of the warnings, so I fixed it.