### PR TITLE
Create service instances per user

### DIFF
--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -10,7 +10,7 @@ function Get-ZLocationBackupFilePath
 
 function Get-ZLocationPipename
 {
-    return 'zlocation'
+    return 'zlocation' + $env:USERNAME
 }
 
 #


### PR DESCRIPTION
Using the same service for each user means the user which happens to
be the first to run 'Import-Module ZLocation', starts the sole service
instance and as such any other users using ZLocation will use the
same z-location.txt. Fix this by simply using a different pipe name
for each user so each account has it's own service instance and hence
uses it's own z-location.txt.

Should fix #35 though I've never used services etc before so I am not 100% sure it is the correct way. It does seem to work without problems though.