### PR TITLE
Rely on USERPROFILE instead of HOMEPATH

### DIFF
--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -5,7 +5,7 @@ $baseAddress = "net.pipe://localhost"
 
 function Get-ZLocationBackupFilePath
 {
-    return (Join-Path $env:HOMEDRIVE (Join-Path $env:HOMEPATH 'z-location.txt'))
+    return (Join-Path $env:USERPROFILE 'z-location.txt')
 }
 
 function Get-ZLocationPipename


### PR DESCRIPTION
Processes started with alternate credentals using 'runas' functionality
(either with the runas command or with the 'Run as different user' menu
in explorer do not use the same HOMEDRIVE and HOMEPATH variables as
when the process is started by the logged-in user.
As such when starting Powershell using runas, the zlocation.txt ends
up in e.g. the current working directory when the process was started
(when starting shells as different user in Conemu for instance) or in
c:\windows\system32 (using runas on commandline).
The USERPROFILE environment variable does not have this problem and
always points to the same path so this is more robust.

I'm aware this might be a breaking change for existing users who have altered their HOMEPATH but arguable it is the correct thing, see e.g. https://stackoverflow.com/a/36392591/128384