### PR TITLE
Tab Expansion bug fix

### DIFF
--- a/ZLocation.Tests/ZLocation.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Tests.ps1
@@ -70,4 +70,15 @@ Describe 'ZLocation' {
         }
     }
 
+    InModuleScope ZLocation {
+        Context 'Alias matching regex' {
+            It 'Should match the full command name' {
+                'Set-ZLocation whatever' | Should Match $TabExpansionRegex
+            }
+
+            It 'Should match the default "z" alias' {
+                'z whatever' | Should Match $TabExpansionRegex
+            }
+        }
+    }
 }

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -150,7 +150,14 @@ Register-PromptHook
 Set-Alias -Name z -Value Set-ZLocation
 
 # Create a list of aliases for Set-Zlocation, and add Set-Zlocation
-$szlAliases = ((Get-Alias -Definition Set-ZLocation | %{[regex]::Escape($_)}) + 'Set-ZLocation')
+$szlAliases = @(
+    foreach ($alias in Get-Alias -Definition Set-ZLocation) {
+        [regex]::Escape($alias.Name)
+    }
+
+    'Set-ZLocation'
+)
+
 
 # Make a regex to match starting a string with an alias followed by a space
 $TabExpansionRegex = '^('+$($szlAliases -join '|')+') '


### PR DESCRIPTION
Latest code change that set up a regex to match all aliases for Set-ZLocation had a bug.  If only a single alias existed, the `$szlAliases` variable would wind up being a string instead of an array of two strings (because of how PowerShell `+` operator works based on what's on the left.)  They wouldn't wind up joined with the `|` character, which broke the regex and caused tab expansion to fail.  AFAIK, this is the default setup for anyone who hasn't added other aliases for Set-ZLocation to their profile.

New code ensures that `$szlAliases` is always an array, and is refactored slightly for readability.