### PR TITLE
Use "Register-ArgumentCompleter" for tab-completions

### DIFF
--- a/ZLocation.Tests/ZLocation.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Tests.ps1
@@ -40,16 +40,4 @@ Describe 'ZLocation' {
             }
         }
     }
-
-    InModuleScope ZLocation {
-        Context 'Alias matching regex' {
-            It 'Should match the full command name' {
-                'Set-ZLocation whatever' | Should Match $TabExpansionRegex
-            }
-
-            It 'Should match the default "z" alias' {
-                'z whatever' | Should Match $TabExpansionRegex
-            }
-        }
-    }
 }

--- a/ZLocation.Tests/ZLocation.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Tests.ps1
@@ -40,4 +40,37 @@ Describe 'ZLocation' {
             }
         }
     }
+
+    Context 'tab completion' {
+        Function Complete($command) {
+            [System.Management.Automation.CommandCompletion]::CompleteInput($command, $command.Length, @{}).CompletionMatches.ListItemText
+            (TabExpansion2 $command $command.Length).CompletionMatches.ListItemText
+        }
+        BeforeEach {
+            Update-ZLocation 'prefixABC'
+            Update-ZLocation 'prefixDEF'
+            Update-ZLocation 'notthisGHI'
+            Update-ZLocation 'notthisJKL'
+        }
+        AfterEach {
+            Remove-ZLocation -path 'prefixABC'
+            Remove-ZLocation -path 'prefixDEF'
+            Remove-ZLocation -path 'notthisGHI'
+            Remove-ZLocation -path 'notthisJKL'
+        }
+        It 'should offer only completions matching entered text' {
+            $completions = Complete 'z refix'
+            $completions | Should -Contain 'prefixABC'
+            $completions | Should -Contain 'prefixDEF'
+            $completions | Should -Not -Contain 'notthisGHI'
+            $completions | Should -Not -Contain 'notthisJKL'
+        }
+        It 'should offer all completions when invoked without prefix' {
+            $completions = Complete 'z '
+            $completions | Should -Contain 'prefixABC'
+            $completions | Should -Contain 'prefixDEF'
+            $completions | Should -Contain 'notthisGHI'
+            $completions | Should -Contain 'notthisJKL'
+        }
+    }
 }

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -147,5 +147,3 @@ Set-Alias -Name z -Value Set-ZLocation
 Export-ModuleMember -Function @('Set-ZLocation', 'Get-ZLocation', 'Pop-ZLocation', 'Remove-ZLocation') -Alias z
 # export this function to make it accessible from prompt
 Export-ModuleMember -Function Update-ZLocation
-
-export-modulemember -function Find-Matches

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -66,8 +66,14 @@ Update-ZLocation $pwd
 #
 # Tab completion.
 #
-if (Test-Path Function:\TabExpansion) {
-    Rename-Item Function:\TabExpansion PreZTabExpansion
+Register-ArgumentCompleter -CommandName Set-ZLocation -ParameterName match -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    # Omit first item (command name) and empty strings
+    $i = $commandAst.CommandElements.Count
+    [string[]]$query = if($i -gt 1) {
+        $commandAst.CommandElements[1..($i-1)] | ForEach-Object { $_.toString()}
+    }
+    Find-Matches (Get-ZLocation) $query | Get-EscapedPath
 }
 
 function Get-EscapedPath
@@ -91,20 +97,6 @@ function Get-EscapedPath
     }
 }
 
-function global:TabExpansion($line, $lastWord) {
-    switch -regex ($line) {
-        $TabExpansionRegex {
-        # "^(Set-ZLocation|z|j|pineapple) .*" {
-            $arguments = $line -split ' ' | Where { $_.length -gt 0 } | select -Skip 1
-            Find-Matches (Get-ZLocation) $arguments | Get-EscapedPath
-        }
-        default {
-            if (Test-Path Function:\PreZTabExpansion) {
-                PreZTabExpansion $line $lastWord
-            }
-        }
-    }
-}
 #
 # End of tab completion.
 #
@@ -115,21 +107,21 @@ function Pop-ZLocation
     Pop-Location
 }
 
-function Set-ZLocation()
+function Set-ZLocation([Parameter(ValueFromRemainingArguments)]$match)
 {
     Register-PromptHook
 
-    if (-not $args) {
-        $args = @()
+    if (-not $match) {
+        $match= @()
     }
 
     # Special case to enable Pop-Location.
-    if (($args.Count -eq 1) -and ($args[0] -eq '-')) {
+    if (($match.Count -eq 1) -and ($match[0] -eq '-')) {
         Pop-ZLocation
         return
     }
 
-    $matches = Find-Matches (Get-ZLocation) $args
+    $matches = Find-Matches (Get-ZLocation) $match
     $pushDone = $false
     foreach ($match in $matches) {
         if (Test-path $match) {
@@ -150,19 +142,8 @@ Register-PromptHook
 
 Set-Alias -Name z -Value Set-ZLocation
 
-# Create a list of aliases for Set-Zlocation, and add Set-Zlocation
-$szlAliases = @(
-    foreach ($alias in Get-Alias -Definition Set-ZLocation) {
-        [regex]::Escape($alias.Name)
-    }
-
-    'Set-ZLocation'
-)
-
-
-# Make a regex to match starting a string with an alias followed by a space
-$TabExpansionRegex = '^('+$($szlAliases -join '|')+') '
-
 Export-ModuleMember -Function @('Set-ZLocation', 'Get-ZLocation', 'Pop-ZLocation', 'Remove-ZLocation') -Alias z
 # export this function to make it accessible from prompt
 Export-ModuleMember -Function Update-ZLocation
+
+export-modulemember -function Find-Matches

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -66,14 +66,16 @@ Update-ZLocation $pwd
 #
 # Tab completion.
 #
-Register-ArgumentCompleter -CommandName Set-ZLocation -ParameterName match -ScriptBlock {
-    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
-    # Omit first item (command name) and empty strings
-    $i = $commandAst.CommandElements.Count
-    [string[]]$query = if($i -gt 1) {
-        $commandAst.CommandElements[1..($i-1)] | ForEach-Object { $_.toString()}
+if(Get-Command -Name Register-ArgumentCompleter -ErrorAction Ignore) {
+    Register-ArgumentCompleter -CommandName Set-ZLocation -ParameterName match -ScriptBlock {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        # Omit first item (command name) and empty strings
+        $i = $commandAst.CommandElements.Count
+        [string[]]$query = if($i -gt 1) {
+            $commandAst.CommandElements[1..($i-1)] | ForEach-Object { $_.toString()}
+        }
+        Find-Matches (Get-ZLocation) $query | Get-EscapedPath
     }
-    Find-Matches (Get-ZLocation) $query | Get-EscapedPath
 }
 
 function Get-EscapedPath


### PR DESCRIPTION
I noticed the existing tab completion code was a bit hacky, so I refactored it to use `Register-ArgumentCompleter`.  It seems to work just as well but now it's a bit cleaner since it only runs when tab-completing the `z` command.  Also it should work with any aliases, even if they're added after the module loads.