### PR TITLE
Fixes #61 and adds failing test

### DIFF
--- a/ZLocation.Tests/ZLocation.Storage.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Storage.Tests.ps1
@@ -43,6 +43,12 @@ Describe 'ZLocation.Storage' {
             $path2 | Should -BeIn $h.Keys # Fails in Pester 3 - no BeIn
         }
 
+        It 'can handle multiple paths differing only by capitalization' {
+            Add-ZWeight -path 'FOO' -weight 1
+            Add-ZWeight -path 'foo' -weight 1
+            Get-ZLocation
+        }
+
     } finally {
 
         It 'can remove path' {

--- a/ZLocation.Tests/ZLocation.Storage.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Storage.Tests.ps1
@@ -10,6 +10,8 @@ Describe 'ZLocation.Storage' {
 
         $path = [guid]::NewGuid().Guid
         $path2 = [guid]::NewGuid().Guid
+        $path3 = 'FOO'
+        $path4 = 'foo'
 
         It 'can add weight' {
             $w1 = 6.6
@@ -44,8 +46,8 @@ Describe 'ZLocation.Storage' {
         }
 
         It 'can handle multiple paths differing only by capitalization' {
-            Add-ZWeight -path 'FOO' -weight 1
-            Add-ZWeight -path 'foo' -weight 1
+            Add-ZWeight -path $path3 -weight 1
+            Add-ZWeight -path $path4 -weight 1
             Get-ZLocation
         }
 
@@ -53,6 +55,8 @@ Describe 'ZLocation.Storage' {
 
         It 'can remove path' {
             Remove-ZLocation -path $path2
+            Remove-ZLocation -path $path3
+            Remove-ZLocation -path $path4
             $h = Get-ZLocation
             $h.Count | Should Be ($originalCount + 1)
 

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -6,7 +6,7 @@ Import-Module (Join-Path $PSScriptRoot 'ZLocation.Search.psm1')
 function Get-ZLocation($Match)
 {
     $service = Get-ZService
-    $hash = @{}
+    $hash = [Collections.HashTable]::new()
     foreach ($item in $service.Get())
     {
         $hash.add($item.path, $item.weight)


### PR DESCRIPTION
In cases when two paths differ only by capitalization, we need to keep both in the DB in case the filesystem is case-sensitive.

I suppose we could opt to remove duplicates on Windows; keep them on Mac and Linux?  But this fix was easier.