### PR TITLE
explicitly declares exported functions in manifest; apparently this is faster

### DIFF
--- a/ZLocation/ZLocation.psd1
+++ b/ZLocation/ZLocation.psd1
@@ -64,16 +64,25 @@ RequiredAssemblies = @("LiteDB\LiteDB.dll")
 # NestedModules = @("ZLocation.Storage.psm1", "ZLocation.Search.psm1")
 
 # Functions to export from this module
-FunctionsToExport = '*'
+FunctionsToExport = @(
+    'Get-ZLocation',
+    'Invoke-ZLocation',
+    'Pop-ZLocation',
+    'Remove-ZLocation',
+    'Set-ZLocation',
+    'Update-ZLocation'
+)
 
 # Cmdlets to export from this module
-CmdletsToExport = '*'
+CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = '*'
+VariablesToExport = @()
 
 # Aliases to export from this module
-AliasesToExport = '*'
+AliasesToExport = @(
+    'z'
+)
 
 # List of all modules packaged with this module
 # ModuleList = @()


### PR DESCRIPTION
Apparently PowerShell is faster when it doesn't need to parse an entire module to know what functions are exported.

https://docs.microsoft.com/en-us/windows-server/administration/performance-tuning/powershell/module-authoring-considerations