### PR TITLE
Sort Invoke-ZLocation output by Path, sort by Weight when match supplied

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -157,18 +157,24 @@ function Invoke-ZLocation
         [Parameter(ValueFromRemainingArguments)][string[]]$match
     )
 
+    $sortProperty = "Path"
+    $sortDescending = $false
+
     $locations = $null
     if ($null -eq $match) {
         $locations = Get-ZLocation
     }
     elseif (($match.Length -gt 0) -and ($match[0] -eq '-l')) {
         $locations = Get-ZLocation ($match | Select-Object -Skip 1)
+        $sortProperty = "Weight"
+        $sortDescending = $true
     }
 
     if ($locations) {
         $locations |
             ForEach-Object {$_.GetEnumerator()} |
-            ForEach-Object {[PSCustomObject]@{Weight = $_.Value; Path = $_.Name}}
+            ForEach-Object {[PSCustomObject]@{Weight = $_.Value; Path = $_.Name}} |
+            Sort-Object -Property $sortProperty -Descending:$sortDescending
         return
     }
 


### PR DESCRIPTION
This will sort by Path ascending when you execute just `z`.  
When you specify `z -l [term]` then it will sort by Weight descending.  
I think that makes the most sense in this case since you see the best match at the top.