### PR TITLE
Fix - using ZLocation on Windows PowerShell creates errors in $Error

### DIFF
--- a/ZLocation/ZLocation.Search.psm1
+++ b/ZLocation/ZLocation.Search.psm1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version Latest
 
-if((Get-Variable IsWindows -ErrorAction SilentlyContinue) -eq $null) { $IsWindows = $true }
+if ((Get-Variable IsWindows -ErrorAction Ignore) -eq $null) { $IsWindows = $true }
 
 function Find-Matches([hashtable]$hash, [string[]]$query)
 {

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -58,7 +58,7 @@ function Get-ZLocationLegacyBackupFilePath
  Exposes $db and $collection variables for use by the $scriptblock
 #>
 function dboperation($private:scriptblock) {
-    $Private:Mode = if( Get-Variable IsMacOS -ErrorAction SilentlyContinue ) { 'Exclusive' } else { 'Shared' }
+    $Private:Mode = if (Get-Variable IsMacOS -ErrorAction Ignore) { 'Exclusive' } else { 'Shared' }
     # $db and $collection will be in-scope within $scriptblock
     $db = DBOpen "Filename=$( Get-ZLocationDatabaseFilePath ); Mode=$Mode"
     $collection = Get-DBCollection $db 'location'


### PR DESCRIPTION
This is what I see in $Error after starting Windows PowerShell:
```
11-18 13:12:18 51ms 7> $Error
Get-Variable : Cannot find a variable with the name 'IsMacOS'.
At C:\Users\Keith\Documents\WindowsPowerShell\Modules\ZLocation\1.1.0\ZLocation.Service.psm1:61 char:25
+ ... :Mode = if( Get-Variable IsMacOS -ErrorAction SilentlyContinue ) { 'E ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (IsMacOS:String) [Get-Variable], ItemNotFoundException
    + FullyQualifiedErrorId : VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand

Get-Variable : Cannot find a variable with the name 'IsMacOS'.
At C:\Users\Keith\Documents\WindowsPowerShell\Modules\ZLocation\1.1.0\ZLocation.Service.psm1:61 char:25
+ ... :Mode = if( Get-Variable IsMacOS -ErrorAction SilentlyContinue ) { 'E ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (IsMacOS:String) [Get-Variable], ItemNotFoundException
    + FullyQualifiedErrorId : VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand
```
This PR eliminates these errors.
