### PR TITLE
Move to unvisited directories if one is provided

### DIFF
--- a/ZLocation.Tests/ZLocation.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Tests.ps1
@@ -39,6 +39,24 @@ Describe 'ZLocation' {
                 Remove-ZLocation $newDirFullPath
             }
         }
+
+        It 'can navigate to an unvisited directory' {
+            try {
+                $newdirectory = [guid]::NewGuid().Guid
+                $curDirFullPath = ($pwd).Path
+                mkdir $newdirectory
+                $newDirFullPath = Join-Path $curDirFullPath $newdirectory
+
+                # do the jump
+                z $newdirectory
+                ($pwd).Path | Should Be $newDirFullPath
+            }
+            finally {
+                cd $curDirFullPath
+                Remove-Item -rec -force $newdirectory
+                Remove-ZLocation $newDirFullPath
+            }
+        }
     }
 
     Context 'tab completion' {

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -145,7 +145,12 @@ function Set-ZLocation([Parameter(ValueFromRemainingArguments)][string[]]$match)
         }
     }
     if (-not $pushDone) {
-        Write-Warning "Cannot find matching location"
+        if (($match.Count -eq 1) -and (Test-Path "$match")) {
+            Write-Debug "No matches for $match, attempting Push-Location"
+            Push-Location "$match"
+        } else {
+            Write-Warning "Cannot find matching location"
+        }
     }
 }
 


### PR DESCRIPTION
Hope you don't mind this, @Jaykul! Fixes #15.

Prevents "Cannot find matching location" as described in #15, code by @Jaykul in https://github.com/vors/ZLocation/issues/15#issuecomment-257771102

Tab completion works pretty well: ZLocation can expand paths known to it, then directory tab completion works as normal -- pretty much as described in https://github.com/vors/ZLocation/issues/15#issuecomment-199952253