### PR TITLE
 Changed to force "match" parameter.

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -190,7 +190,7 @@ function Invoke-ZLocation
         return
     }
 
-    Set-ZLocation $match
+    Set-ZLocation -match $match
 }
 
 Register-PromptHook


### PR DESCRIPTION
Without this, passing "z" multiple arguments would force all arguments
to only match the final part of the path.

z sys 32

could successfully match "C:\Windows\system32", but

z win 32

would not.