### PR TITLE
Handle malformed db entries

### DIFF
--- a/ZLocation/ZLocation.Search.psm1
+++ b/ZLocation/ZLocation.Search.psm1
@@ -2,8 +2,11 @@ Set-StrictMode -Version Latest
 
 if ((Get-Variable IsWindows -ErrorAction Ignore) -eq $null) { $IsWindows = $true }
 
-function Find-Matches([hashtable]$hash, [string[]]$query)
-{
+function Find-Matches {
+    param (
+        [Parameter(Mandatory=$true)] [hashtable]$hash, 
+        [string[]]$query
+    )
     $hash = $hash.Clone()
     foreach ($key in ($hash.GetEnumerator() | %{$_.Name}))
     {
@@ -39,7 +42,11 @@ function Find-Matches([hashtable]$hash, [string[]]$query)
     }
 }
 
-function Start-WithPrefix([string]$Path, [string]$lowerPrefix) {
+function Start-WithPrefix {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path, 
+        [Parameter(Mandatory=$true)] [string]$lowerPrefix
+    )
     $lowerLeaf = (Split-Path -Leaf $Path).ToLower()
     return $lowerLeaf.StartsWith($lowerPrefix)
 }
@@ -49,8 +56,11 @@ function IsExactMatch([string]$Path, [string]$lowerPrefix) {
     return $lowerLeaf -eq $lowerPrefix
 }
 
-function Test-FuzzyMatch([string]$path, [string[]]$query)
-{
+function Test-FuzzyMatch {
+    param (
+        [Parameter(Mandatory=$true)] [string]$path,
+        [string[]]$query
+    )
     function contains([string]$left, [string]$right) {
         return [bool]($left.IndexOf($right, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
     }

--- a/ZLocation/ZLocation.Search.psm1
+++ b/ZLocation/ZLocation.Search.psm1
@@ -51,7 +51,11 @@ function Start-WithPrefix {
     return $lowerLeaf.StartsWith($lowerPrefix)
 }
 
-function IsExactMatch([string]$Path, [string]$lowerPrefix) {
+function IsExactMatch {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path, 
+        [Parameter(Mandatory=$true)] [string]$lowerPrefix
+    )
     $lowerLeaf = (Split-Path -Leaf $Path).ToLower()
     return $lowerLeaf -eq $lowerPrefix
 }

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -76,7 +76,10 @@ function Get-ZLocationLegacyBackupFilePath
  See: https://github.com/mbdavid/LiteDB/wiki/Concurrency
  Exposes $db and $collection variables for use by the $scriptblock
 #>
-function dboperation($private:scriptblock) {
+function dboperation {
+    param (
+        [Parameter(Mandatory=$true)] $private:scriptblock
+    )
     $Private:Mode = if (Get-Variable IsMacOS -ErrorAction Ignore) { 'Exclusive' } else { 'Shared' }
     # $db and $collection will be in-scope within $scriptblock
     $db = DBOpen "Filename=$( Get-ZLocationDatabaseFilePath ); Mode=$Mode"

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -6,8 +6,13 @@ class Service {
     [Collections.Generic.IEnumerable[Location]] Get() {
         return (dboperation {
             # Return an enumerator of all location entries
-            [Location[]]$arr = DBFind $collection ([LiteDB.Query]::All()) ([Location])
-            ,$arr
+            try {
+                [Location[]]$arr = DBFind $collection ([LiteDB.Query]::All()) ([Location])
+                , $arr
+            }
+            catch [System.InvalidCastException] {
+                throw [System.InvalidCastException] "Caught InvalidCastException when reading db, probably [LiteDB.ObjectId] entry present."
+            }
         })
     }
     [void] Add([string]$path, [double]$weight) {
@@ -68,7 +73,7 @@ function dboperation($private:scriptblock) {
             try {
                 & $private:scriptblock
                 return
-            } catch {
+            } catch [System.IO.IOException] {
                 $rand = Get-Random 100
                 Start-Sleep -Milliseconds (($__i + 1) * 100 - $rand)
             }

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -74,12 +74,15 @@ function dboperation($private:scriptblock) {
                 & $private:scriptblock
                 return
             } catch [System.IO.IOException] {
-                $rand = Get-Random 100
-                Start-Sleep -Milliseconds (($__i + 1) * 100 - $rand)
+                # The process cannot access the file '~\z-location.db' because it is being used by another process.
+                if ($__i -lt 4 ) {
+                    $rand = Get-Random 100
+                    Start-Sleep -Milliseconds (($__i + 1) * 100 - $rand)
+                } else {
+                    throw [System.IO.IOException] 'Cannot execute database operation after 5 attempts, please open an issue on https://github.com/vors/ZLocation'
+                }
             }
         }
-        Write-Error $error[0]
-        throw 'Cannot execute database operation after 5 attempts, please open an issue on https://github.com/vors/ZLocation'
     } finally {
         $db.dispose()
     }

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -23,7 +23,11 @@ function Get-ZLocation($Match)
     return $hash
 }
 
-function Add-ZWeight([string]$path, [double]$weight) {
+function Add-ZWeight {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path,
+        [Parameter(Mandatory=$true)] [double]$Weight
+    )
     $service = Get-ZService
     $service.Add($path, $weight)
 }

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -28,7 +28,10 @@ function Add-ZWeight([string]$path, [double]$weight) {
     $service.Add($path, $weight)
 }
 
-function Remove-ZLocation([string]$path) {
+function Remove-ZLocation {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path
+    )
     $service = Get-ZService
     $service.Remove($path)
 }

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -37,8 +37,11 @@ function Update-ZLocation([string]$path)
 (Get-Variable pwd).attributes.Add((new-object ValidateScript { Update-ZLocation $_.Path; return $true }))
 #>
 
-function Update-ZLocation([string]$path)
+function Update-ZLocation
 {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path
+    )
     Add-ZWeight $path 1.0
 }
 


### PR DESCRIPTION
Some of the errors reported at least are due to malformed db entries, possibly caused by adding "locations" without paths to the db. Three things to do:

- [x] Identify when they're appearing and try to be obvious/helpful about it
- [x] Remove them from the database.
- [x] Stop it happening again. Looks like this is going to be mandatory parameters and defaults on existing cmdlets #86 