### PR TITLE
Add VS2017, 2019, and Ubuntu 1804 AppVeyor images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,10 @@ version: 1.0.0.{build}
 
 image:
 - Visual Studio 2015
+- Visual Studio 2017
+- Visual Studio 2019
 - Ubuntu
+- Ubuntu1804
 
 install:
   - ps: Install-Module Pester -Scope CurrentUser -Force


### PR DESCRIPTION
VS2015 is 2012R2, so add VS2017 (Server 2016) and VS2019 (Server 2019) to test on more recent versions of Windows too.