### PR TITLE
Convert ZService to functions

### DIFF
--- a/ZLocation.Tests/ZLocation.Service.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Service.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'ZLocation.Service' {
             $count = $service.get() | Measure-Object | Select-Object -ExpandProperty Count
 
             It 'Adds and retrieves a location' {
-                $service.add($path, 1)
+                Update-ZDBLocation -Path $path
                 $service.get() | Should -HaveCount ($count + 1)
                 $l = [Location]::new()
                 $l.path = $path
@@ -36,7 +36,7 @@ Describe 'ZLocation.Service' {
             }
 
             It 'Adds and removes a location' {
-                $service.add($path, 1)
+                Update-ZDBLocation -Path $path
                 Remove-ZDBLocation $path
                 $service.get() | Measure-Object | Select-Object -ExpandProperty Count | Should -Be $count
             }

--- a/ZLocation.Tests/ZLocation.Service.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Service.Tests.ps1
@@ -1,0 +1,76 @@
+Describe 'ZLocation.Service' {
+    Import-Module $PSScriptRoot\..\ZLocation\ZLocation.Service.psd1 -Force
+    . "$PSScriptRoot/_mocks.ps1"
+
+    Context 'Testing database init' {
+        InModuleScope ZLocation.Service {
+            $dbpath = Get-ZLocationDatabaseFilePath
+            $testdbpattern = '*z-location-tests.db'
+            if ($dbpath -notlike $testdbpattern) {throw 'Not using test database, aborting tests'}
+            if (-not (Test-ZLocationDBUnlocked)) {throw 'Database is locked, aborting tests'}
+
+            # It 'Is referring to test DB' {
+            #     $dbpath | Should -BeLike $testdbpattern
+            # }
+        }
+    }
+
+    Context 'Testing database functionality' {
+        InModuleScope ZLocation.Service {
+            $dbpath = Get-ZLocationDatabaseFilePath
+            $testdbpattern = '*z-location-tests.db'
+            if ($dbpath -notlike $testdbpattern) {throw 'Not using test database, aborting tests'}
+            if (-not (Test-ZLocationDBUnlocked)) {throw 'Database is locked, aborting tests'}
+
+            $path = [guid]::NewGuid().Guid 
+            $service = Get-ZService
+            $count = $service.get() | Measure-Object | Select-Object -ExpandProperty Count
+
+            It 'Adds and retrieves a location' {
+                $service.add($path, 1)
+                $service.get() | Should -HaveCount ($count + 1)
+                $l = [Location]::new()
+                $l.path = $path
+                $l.weight = 1
+                $service.get() | Where-Object { $_.Path -eq $path } | Should -HaveCount 1
+            }
+
+            It 'Adds and removes a location' {
+                $service.add($path, 1)
+                $service.Remove($path)
+                $service.get() | Measure-Object | Select-Object -ExpandProperty Count | Should -Be $count
+            }
+        }
+    }
+
+    Context "Malformed DB entries" {
+        try {
+            # Connect to the database and add some malformed entries
+            Add-Type -Path $PSScriptRoot\..\ZLocation\LiteDB\LiteDB.dll
+            $connectionString = "Filename=$($testDb); Mode=Shared"
+            $db = [LiteDB.LiteDatabase]::new($connectionString)
+            $collection = $db.GetCollection('Location')
+            $oidquery = [LiteDB.Query]::Where('_id',{$args -like '{"$oid":"*"}'})
+            
+            # Create and insert a malformed location
+            $bsondocument = [LiteDB.BsonDocument]::new()
+            $bsondocument['weight'] = 1234
+            $collection.Insert($bsondocument)
+
+            It "confirms malformed entries inserted" {
+                # This actually tests the query more than anything.
+                $malformedEntries = (,$collection.Find($oidquery))
+                $malformedEntries | Should -HaveCount 1
+            }
+
+            It "can remove malformed location entries" {
+                $service = Get-ZService
+                $service.get()
+                $malformedEntries = $collection.Find($oidquery)
+                $malformedEntries | Should -HaveCount 0
+            }
+        } finally {
+            $db.Dispose()
+        }
+    }
+}

--- a/ZLocation.Tests/ZLocation.Service.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Service.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'ZLocation.Service' {
 
             It 'Adds and removes a location' {
                 $service.add($path, 1)
-                $service.Remove($path)
+                Remove-ZDBLocation $path
                 $service.get() | Measure-Object | Select-Object -ExpandProperty Count | Should -Be $count
             }
         }

--- a/ZLocation.Tests/ZLocation.Service.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Service.Tests.ps1
@@ -64,8 +64,12 @@ Describe 'ZLocation.Service' {
             }
 
             It "can remove malformed location entries" {
+                # Ensure nothing else can be connecting to $db to placate AppVeyor.
+                $db.Dispose()
                 $service = Get-ZService
                 $service.get()
+                $db = [LiteDB.LiteDatabase]::new($connectionString)
+                $collection = $db.GetCollection('Location')
                 $malformedEntries = $collection.Find($oidquery)
                 $malformedEntries | Should -HaveCount 0
             }

--- a/ZLocation.Tests/ZLocation.Service.Tests.ps1
+++ b/ZLocation.Tests/ZLocation.Service.Tests.ps1
@@ -23,22 +23,21 @@ Describe 'ZLocation.Service' {
             if (-not (Test-ZLocationDBUnlocked)) {throw 'Database is locked, aborting tests'}
 
             $path = [guid]::NewGuid().Guid 
-            $service = Get-ZService
-            $count = $service.get() | Measure-Object | Select-Object -ExpandProperty Count
+            $count = Get-ZDBLocation| Measure-Object | Select-Object -ExpandProperty Count
 
             It 'Adds and retrieves a location' {
                 Update-ZDBLocation -Path $path
-                $service.get() | Should -HaveCount ($count + 1)
+                Get-ZDBLocation | Should -HaveCount ($count + 1)
                 $l = [Location]::new()
                 $l.path = $path
                 $l.weight = 1
-                $service.get() | Where-Object { $_.Path -eq $path } | Should -HaveCount 1
+                Get-ZDBLocation | Where-Object { $_.Path -eq $path } | Should -HaveCount 1
             }
 
             It 'Adds and removes a location' {
                 Update-ZDBLocation -Path $path
                 Remove-ZDBLocation $path
-                $service.get() | Measure-Object | Select-Object -ExpandProperty Count | Should -Be $count
+                Get-ZDBLocation | Measure-Object | Select-Object -ExpandProperty Count | Should -Be $count
             }
         }
     }
@@ -66,8 +65,7 @@ Describe 'ZLocation.Service' {
             It "can remove malformed location entries" {
                 # Ensure nothing else can be connecting to $db to placate AppVeyor.
                 $db.Dispose()
-                $service = Get-ZService
-                $service.get()
+                Get-ZDBLocation
                 $db = [LiteDB.LiteDatabase]::new($connectionString)
                 $collection = $db.GetCollection('Location')
                 $malformedEntries = $collection.Find($oidquery)

--- a/ZLocation/ZLocation.Service.psd1
+++ b/ZLocation/ZLocation.Service.psd1
@@ -4,7 +4,7 @@ GUID = '3d256bab-55d1-459c-8673-1d9d7ca8554a'
 # Assembly must be loaded first or else powershell class will fail to compile
 RequiredAssemblies = @("$PSScriptRoot/LiteDB/LiteDB.dll")
 RootModule = 'ZLocation.Service.psm1'
-FunctionsToExport = @('Get-ZService','Get-ZDBLocation','Update-ZDBLocation','Remove-ZDBLocation')
+FunctionsToExport = @('Get-ZDBLocation','Update-ZDBLocation','Remove-ZDBLocation')
 CmdletsToExport = @()
 VariablesToExport = @()
 AliasesToExport = @()

--- a/ZLocation/ZLocation.Service.psd1
+++ b/ZLocation/ZLocation.Service.psd1
@@ -4,7 +4,7 @@ GUID = '3d256bab-55d1-459c-8673-1d9d7ca8554a'
 # Assembly must be loaded first or else powershell class will fail to compile
 RequiredAssemblies = @("$PSScriptRoot/LiteDB/LiteDB.dll")
 RootModule = 'ZLocation.Service.psm1'
-FunctionsToExport = @('Get-ZService','Update-ZDBLocation','Remove-ZDBLocation')
+FunctionsToExport = @('Get-ZService','Get-ZDBLocation','Update-ZDBLocation','Remove-ZDBLocation')
 CmdletsToExport = @()
 VariablesToExport = @()
 AliasesToExport = @()

--- a/ZLocation/ZLocation.Service.psd1
+++ b/ZLocation/ZLocation.Service.psd1
@@ -4,7 +4,7 @@ GUID = '3d256bab-55d1-459c-8673-1d9d7ca8554a'
 # Assembly must be loaded first or else powershell class will fail to compile
 RequiredAssemblies = @("$PSScriptRoot/LiteDB/LiteDB.dll")
 RootModule = 'ZLocation.Service.psm1'
-FunctionsToExport = @('Get-ZService')
+FunctionsToExport = @('Get-ZService','Remove-ZDBLocation')
 CmdletsToExport = @()
 VariablesToExport = @()
 AliasesToExport = @()

--- a/ZLocation/ZLocation.Service.psd1
+++ b/ZLocation/ZLocation.Service.psd1
@@ -4,7 +4,7 @@ GUID = '3d256bab-55d1-459c-8673-1d9d7ca8554a'
 # Assembly must be loaded first or else powershell class will fail to compile
 RequiredAssemblies = @("$PSScriptRoot/LiteDB/LiteDB.dll")
 RootModule = 'ZLocation.Service.psm1'
-FunctionsToExport = @('Get-ZService','Remove-ZDBLocation')
+FunctionsToExport = @('Get-ZService','Update-ZDBLocation','Remove-ZDBLocation')
 CmdletsToExport = @()
 VariablesToExport = @()
 AliasesToExport = @()

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -2,9 +2,6 @@ Set-StrictMode -Version Latest
 
 Import-Module -Prefix DB (Join-Path $PSScriptRoot 'ZLocation.LiteDB.psd1')
 
-class Service {
-}
-
 # Get the locations in the database and their weights as [Location]s
 function Get-ZDBLocation {
         return (dboperation {
@@ -139,8 +136,6 @@ dboperation {
     $collection.EnsureIndex('path')
 }
 
-$service = [Service]::new()
-
 # Migrate legacy backup into database if appropriate
 if((-not $dbExists) -and $legacyBackupExists) {
     Write-Warning "ZLocation changed storage from $legacyBackupPath to $(Get-ZLocationDatabaseFilePath), feel free to remove the old txt file"
@@ -148,8 +143,4 @@ if((-not $dbExists) -and $legacyBackupExists) {
         $split = $_ -split "`t"
         Update-ZDBLocation $split[0] $split[1]
     }
-}
-
-Function Get-ZService {
-    ,$service
 }

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -43,11 +43,17 @@ class Service {
             }
         }
     }
-    [void] Remove([string]$path) {
-        dboperation {
-            # Use DB's internal column name, not mapped name
-            DBDelete $collection ([LiteDB.Query]::EQ('_id', [LiteDB.BSONValue]::new($path)))
-        }
+}
+
+# Remove a location from the database
+function Remove-ZDBLocation {
+    param (
+        # The location to remove from the database
+        [Parameter(Mandatory=$true)] [string]$Path
+    )
+    dboperation {
+        # Use DB's internal column name, not mapped name
+        DBDelete $collection ([LiteDB.Query]::EQ('_id', [LiteDB.BSONValue]::new($path)))
     }
 }
 

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -3,7 +3,10 @@ Set-StrictMode -Version Latest
 Import-Module -Prefix DB (Join-Path $PSScriptRoot 'ZLocation.LiteDB.psd1')
 
 class Service {
-    [Collections.Generic.IEnumerable[Location]] Get() {
+}
+
+# Get the locations in the database and their weights as [Location]s
+function Get-ZDBLocation {
         return (dboperation {
             # Return an enumerator of all location entries
             try {
@@ -28,7 +31,6 @@ class Service {
                 }
             }
         })
-    }
 }
 
 # Increase the weight of a location in the database, adding it if not present.

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -66,9 +66,9 @@ function Remove-ZDBLocation {
 
 class Location {
     [LiteDB.BsonId()]
-    [string] $path;
+    [string] $Path;
 
-    [double] $weight;
+    [double] $Weight;
 }
 
 function Get-ZLocationDatabaseFilePath

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -105,6 +105,15 @@ function dboperation {
     }
 }
 
+function Test-ZLocationDBUnlocked {
+    try {
+        [IO.File]::OpenWrite((Get-ZLocationDatabaseFilePath)).close()
+        $true
+    } catch {
+        $false
+    }
+}
+
 $dbExists = Test-Path (Get-ZLocationDatabaseFilePath)
 $legacyBackupPath = Get-ZLocationLegacyBackupFilePath
 $legacyBackupExists = ($legacyBackupPath -ne $null) -and (Test-Path $legacyBackupPath)

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -5,9 +5,8 @@ Import-Module (Join-Path $PSScriptRoot 'ZLocation.Search.psm1')
 
 function Get-ZLocation($Match)
 {
-    $service = Get-ZService
     $hash = [Collections.HashTable]::new()
-    foreach ($item in $service.Get())
+    foreach ($item in (Get-ZDBLocation))
     {
         $hash.add($item.path, $item.weight)
     }

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -37,8 +37,4 @@ function Remove-ZLocation {
     Remove-ZDBLocation $path
 }
 
-$MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
-    Write-Warning "[ZLocation] module was removed, but service was not closed."
-}
-
 Export-ModuleMember -Function @("Get-ZLocation", "Add-ZWeight", "Remove-ZLocation")

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -36,8 +36,7 @@ function Remove-ZLocation {
     param (
         [Parameter(Mandatory=$true)] [string]$Path
     )
-    $service = Get-ZService
-    $service.Remove($path)
+    Remove-ZDBLocation $path
 }
 
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {

--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -28,8 +28,7 @@ function Add-ZWeight {
         [Parameter(Mandatory=$true)] [string]$Path,
         [Parameter(Mandatory=$true)] [double]$Weight
     )
-    $service = Get-ZService
-    $service.Add($path, $weight)
+    Update-ZDBLocation $path $weight
 }
 
 function Remove-ZLocation {


### PR DESCRIPTION
Get rid of the service and references to it and convert its methods to functions, since a service is no longer used. Also adds a bunch of tests for `ZLocation.Service`.

`ZLocation.Storage` is now a fairly thin wrapper around functions in `ZLocation.Service`, so going forward it'd probably make sense to merge the two.