### PR TITLE
Automatically add Frequent Folders to db

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -199,10 +199,12 @@ function Invoke-ZLocation
 function Get-FrequentFolders {
     If (((Get-Variable IsWindows -ErrorAction Ignore) -or $PSVersionTable.PSVersion.Major -lt 6) -and
             ([environment]::OSVersion.Version.Major -ge 10)) {
-        $QuickAccess = New-Object -ComObject shell.application
-        $QuickAccess.Namespace("shell:::{679f85cb-0220-4080-b29b-5540cc05aab6}").Items() |
-            Where-Object IsFolder |
-            Select-Object -ExpandProperty Path
+        if (-not $ExecutionContext.SessionState.LanguageMode -eq 'ConstrainedLanguage') {
+            $QuickAccess = New-Object -ComObject shell.application
+            $QuickAccess.Namespace("shell:::{679f85cb-0220-4080-b29b-5540cc05aab6}").Items() |
+                Where-Object IsFolder |
+                Select-Object -ExpandProperty Path
+        }
     }
 }
 

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -196,6 +196,18 @@ function Invoke-ZLocation
     Set-ZLocation -match $match
 }
 
+function Get-FrequentFolders {
+    If (((Get-Variable IsWindows -ErrorAction Ignore) -or $PSVersionTable.PSVersion.Major -lt 6) -and
+            ([environment]::OSVersion.Version.Major -ge 10)) {
+        $QuickAccess = New-Object -ComObject shell.application
+        $QuickAccess.Namespace("shell:::{679f85cb-0220-4080-b29b-5540cc05aab6}").Items() |
+            Where-Object IsFolder |
+            Select-Object -ExpandProperty Path
+    }
+}
+
+Get-FrequentFolders | ForEach-Object {Add-ZWeight -Path $_ -Weight 0}
+
 Register-PromptHook
 
 Set-Alias -Name z -Value Invoke-ZLocation


### PR DESCRIPTION
Windows has a list of frequently accessed folders, so use that. Add them with weight zero since we don't know for sure they're useful and to avoid them incrementing every time ZLocation is imported.