### PR TITLE
Add documentation to the command & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ PS C:\dev\ZLocation\ZLocation.Tests>
 
 To see all locations matched to a query `foo` use `z -l foo`.
 
+### Navigating to less common directories with tab completion
+
+If `z mydir` doesn't take you to the correct directory, you can also tab through
+ZLocation's suggestions.
+
+For example, pressing tab with `z src` will take you through all of ZLocation's
+completions for `src`.
+
+### Going back
+
+ZLocation keeps a stack of directories as you jump between them. `z -` will
+"pop" the stack: it will move you to the previous directory you jumped to,
+basically letting you undo your `z` navigation.
+
+If the stack is empty (you have only jumped once), `z -` will take you to your
+original directory.
+
+For example:
+
+```ps
+C:\>z foo
+C:\foo>z bar
+C:\baz\bar> z -
+C:\foo>z -
+C:\>z -
+C:\>#no-op
+```
+
 Goals / Key features
 --------------------
 

--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -158,13 +158,57 @@ function Set-ZLocation([Parameter(ValueFromRemainingArguments)][string[]]$match)
 }
 
 <#
+    .SYNOPSIS
+    Jump to popular directories.
+
+    .DESCRIPTION
     This is the main entry point in the interactive usage of ZLocation.
-    It's intended to be used as an alias z
+    It's intended to be used as an alias z.
 
     Usage:
         z - prints available directories
         z -l foo - prints available directories scoped to foo query
         z foo - jumps into the location that matches foo
+        z foo <TAB> - pressing tab cycles through different matches for foo
+        z - - undos the last z jump.
+
+    .EXAMPLE
+    PS>z
+    Weight Path
+    ------ ----
+        7 C:\Windows
+        1 C:\Windows\System
+        27 C:\WINDOWS\system32
+        [...]
+
+    .EXAMPLE
+    C:\>z foo
+    C:\foo>
+
+    .EXAMPLE
+    C:\>z foo <PRESS TAB; NOT ENTER>
+    C:\>z C:\foo <PRESS TAB AGAIN>
+    C:\>z C:\another_less_popular\foo <PRESS TAB AGAIN>
+    C:\>z C:\least_popular\foo
+    C:\least_popular\foo>
+
+    .EXAMPLE
+    PS>z -l sys
+    Weight Path
+    ------ ----
+        27 C:\WINDOWS\system32
+         1 C:\Windows\System
+
+    .EXAMPLE
+    C:\>z foo
+    C:\foo>z bar
+    C:\baz\bar> z -
+    C:\foo>z -
+    C:\>z -
+    C:\>#no-op
+
+    .LINK
+    https://github.com/vors/ZLocation
 #>
 function Invoke-ZLocation
 {


### PR DESCRIPTION
Today, getting local help for `z` is hard:

```ps
λ z -?

NAME
    Invoke-ZLocation

SYNTAX
    Invoke-ZLocation [[-match] <string[]>]  [<CommonParameters>]


ALIASES
    z


REMARKS
    None
```

This PR adds inline documentation to the command and updates the `README` to document some previously undocumented features.

## What changed?

Specifically:

* Document tab completion in README.
* Document `z -` in README.
* Document basic usage, tab completion, and `z -` in inline help.

## How tested?

* [ ] Used as default ZLocation & `z -?` works.