### PR TITLE
Release version 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 -------------
+## 1.4.2
+* Stop PowerShell < 6 on Windows emitting an error on import. ([#103](https://github.com/vors/ZLocation/issues/103))
+
 ## 1.4.1
 * Resolve an OS detection bug resulting in errors when importing module on macOS ([#100](https://github.com/vors/ZLocation/issues/100)) (Thanks @nheath!)
 

--- a/ZLocation/ZLocation.psd1
+++ b/ZLocation/ZLocation.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ZLocation.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.1'
+ModuleVersion = '1.4.2'
 
 # ID used to uniquely identify this module
 GUID = '18e8ca17-7f67-4f1c-85ff-159373bf66f5'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.1.{build}
+version: 1.4.2.{build}
 
 image:
 - Visual Studio 2015


### PR DESCRIPTION
Changes since v1.4.1:
- Stop PowerShell < 6 on Windows emitting an error on import. (#103)