### PR TITLE
Fix a bug when running in Powershell 7.1

### DIFF
--- a/ZLocation/ZLocation.Storage.psm1
+++ b/ZLocation/ZLocation.Storage.psm1
@@ -9,7 +9,7 @@ function Get-ZLocation($Match)
     $hash = [Collections.HashTable]::new()
     foreach ($item in $service.Get())
     {
-        $hash.add($item.path, $item.weight)
+        $hash[$item.path] = $item.weight
     }
 
     if ($Match)


### PR DESCRIPTION
When running in Powershell 7.1, the Add() statement fails with an
exception because the key has already been added to the hash table.
This change fixes that.

Fixes #112