### PR TITLE
Restrict AppVeyor to Pester v4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,13 @@ image:
 - macOS
 
 install:
-  - ps: Install-Module Pester -Scope CurrentUser -Force
+  - ps: Install-Module Pester -MinimumVersion 4.0 -MaximumVersion 4.99 -Scope CurrentUser -Force
 
 build: false
 
 test_script:
   - ps: |
+        Import-Module Pester -MinimumVersion 4.0 -MaximumVersion 4.99
         $testResultsFile = ".\TestsResults.xml"
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))


### PR DESCRIPTION
Tests aren't migrated to Pester 5, so specify we want v4.