### PR TITLE
Run original Prompt function before ZLocation hook

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -53,8 +53,8 @@ function Register-PromptHook
     if (-not (Test-Path function:\global:ZlocationOrigPrompt)) {
         Copy-Item function:\prompt function:\global:ZlocationOrigPrompt
         $global:ZLocationPromptScriptBlock = {
-            Update-ZLocation $pwd
             ZLocationOrigPrompt
+            Update-ZLocation $pwd
         }
 
         Set-Content -Path function:\prompt -Value $global:ZLocationPromptScriptBlock -Force


### PR DESCRIPTION
#109 Opened a new PR, I changed the branch and rebased on current master (and GitHub doesn't seem to be able to change the source branch for a PR).

Running ZLocation `Update-ZLocation` hook before original Prompt causes issues when Prompt uses `$?` to detect if previous input failed - `$?` always returns `$true`, as the previous call to `Update-ZLocation` succeeded.