### PR TITLE
Add environment variable PS_ZLOCATION_DATABASE_PATH to allow setting a custom database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ C:\>z -
 C:\>#no-op
 ```
 
+### Custom database file location
+
+ZLocation uses a database file to store the list of known directories. By default, it is located at `$HOME\z-location.db`. If you want to use a custom path, set the `PS_ZLOCATION_DATABASE_PATH` environment variable before importing the module.
+
 Goals / Key features
 --------------------
 

--- a/ZLocation/ZLocation.Service.psm1
+++ b/ZLocation/ZLocation.Service.psm1
@@ -60,8 +60,14 @@ class Location {
 
 function Get-ZLocationDatabaseFilePath
 {
-    return (Join-Path $HOME 'z-location.db')
+	$envDbPath = $env:PS_ZLOCATION_DATABASE_PATH
+    if (-not [string]::IsNullOrEmpty($envDbPath)) {
+        return $envDbPath
+    } else {
+        return Join-Path $HOME 'z-location.db'
+    }
 }
+
 # Returns path to legacy ZLocation backup file.
 function Get-ZLocationLegacyBackupFilePath
 {


### PR DESCRIPTION
#114 Opened a new PR, I changed the branch and rebased on current master (and GitHub doesn't seem to be able to change the source branch for a PR).

Solves https://github.com/vors/ZLocation/issues/94.

I though about adding logic to migrate the database from default location to the custom one when set, but there are too many corner cases, so I think it's better to keep the old database file and let user manually move it if he wants to.