### PR TITLE
Add an option to ignore frequent folders

### DIFF
--- a/ZLocation/ZLocation.psm1
+++ b/ZLocation/ZLocation.psm1
@@ -263,9 +263,11 @@ function Clear-NonExistentZLocation {
     }
 }
 
-Get-FrequentFolders | ForEach-Object {
-    if (Test-Path $_) {
-        Add-ZWeight -Path $_ -Weight 0
+if ($args -notcontains "NoFrequentFolders") {
+    Get-FrequentFolders | ForEach-Object {
+        if (Test-Path $_) {
+            Add-ZWeight -Path $_ -Weight 0
+        }
     }
 }
 


### PR DESCRIPTION
Frequent folders are super slow (500ms on my system), and (to me) don't bring any value.  Add option to disable them so my profile import is faster. 

`Import-Module .\ZLocation\ZLocation.psd1 -ArgumentList "NoFrequentFolders"`

Fix #134 